### PR TITLE
Add databases/php56-redis port

### DIFF
--- a/databases/php56-redis/Makefile
+++ b/databases/php56-redis/Makefile
@@ -1,0 +1,22 @@
+# Created by: Benedikt Niessen <ports@niessen.ch>
+# $FreeBSD$
+PORTNAME=       redis
+PORTVERSION=    2.2.8
+PORTREVISION=   1
+CATEGORIES=     databases
+PKGNAMEPREFIX=  php56-
+MAINTAINER=     m.tsatsenko@gmail.com
+COMMENT=        PHP5 extension for Redis
+LICENSE=        PHP301
+USES=           php:ext
+USE_PHP=        session:build
+PHP_VER=        56
+IGNORE_WITH_PHP=        70
+USE_GITHUB=     yes
+GH_ACCOUNT=     nicolasff
+GH_PROJECT=     phpredis
+OPTIONS_DEFINE= IGBINARY
+IGBINARY_DESC=  Build with Igbinary serializer
+IGBINARY_CONFIGURE_ENABLE=      redis-igbinary
+IGBINARY_USE=                   php=igbinary:build
+.include <bsd.port.mk>

--- a/databases/php56-redis/distinfo
+++ b/databases/php56-redis/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1466948805
+SHA256 (nicolasff-phpredis-2.2.8_GH0.tar.gz) = a7c6e2eef70bd8449bab819c8f01d951fcd86ce0417e03675445040236ed4dda
+SIZE (nicolasff-phpredis-2.2.8_GH0.tar.gz) = 198401

--- a/databases/php56-redis/pkg-descr
+++ b/databases/php56-redis/pkg-descr
@@ -1,0 +1,6 @@
+This extension provides an API for communicating with Redis database,
+a persistent key-value database with built-in net interface written
+in ANSI-C for Posix systems.
+It is a fork of alfonsojimenez's phpredis, adding many methods and
+fixing a lot of issues.
+WWW: https://github.com/nicolasff/phpredis


### PR DESCRIPTION
https://svnweb.freebsd.org/ports/head/databases/php56-redis/?pathrev=434178

Tested to compile and install on the latest FreeBSD 13.1